### PR TITLE
qmldir: expose NotificationService component

### DIFF
--- a/base/qml/WebOSCompositorBase/qmldir
+++ b/base/qml/WebOSCompositorBase/qmldir
@@ -25,6 +25,7 @@ FullscreenView 1.0 views/FullscreenView.qml
 KeyboardView 1.0 views/KeyboardView.qml
 Launcher 1.0 views/Launcher.qml
 NotificationView 1.0 views/NotificationView.qml
+NotificationService 1.0 views/notification/NotificationService.qml
 OverlayView 1.0 views/OverlayView.qml
 PopupView 1.0 views/PopupView.qml
 Spinner 1.0 views/Spinner.qml


### PR DESCRIPTION
On mobile phone it can be convenient to have other ways of displaying notifications.
In order to propose a more integrated UI for notifications, and to maximiwe the code reuse from OSE, we need to re-use the NotificationService component from WebOSCompositorBase.
