### PR TITLE
Allow configuring LSM to setup wayland screen name via WAYLAND_DISPLAY_LSM

### DIFF
--- a/modules/weboscompositor/weboscompositorconfig.cpp
+++ b/modules/weboscompositor/weboscompositorconfig.cpp
@@ -62,11 +62,22 @@ WebOSCompositorConfig::WebOSCompositorConfig()
             m_displayCount = 1;
     }
     m_primaryScreen = QString::fromLatin1(qgetenv("WEBOS_COMPOSITOR_PRIMARY_SCREEN"));
-    if (Q_UNLIKELY(m_primaryScreen.isEmpty())) {
+    if (Q_UNLIKELY(m_primaryScreen.isEmpty()))
+    {
         if (m_outputList.size() > 0)
             m_primaryScreen = m_outputList[0];
         if (Q_UNLIKELY(m_primaryScreen.isEmpty()))
-            m_primaryScreen = QGuiApplication::primaryScreen()->name();
+        {
+            QScreen *primaryScreen = QGuiApplication::primaryScreen();
+            if (primaryScreen)
+            {
+                m_primaryScreen = QGuiApplication::primaryScreen()->name();
+            }
+            else
+            {
+                qWarning() << "No primary screen returned from QGuiApplication";
+            }
+        }
     }
     QJsonObject primary = m_outputConfigs.value(m_primaryScreen);
     if (!primary.isEmpty()) {

--- a/modules/weboscompositor/weboscorecompositor.cpp
+++ b/modules/weboscompositor/weboscorecompositor.cpp
@@ -409,8 +409,9 @@ void WebOSCoreCompositor::checkDaemonFiles()
     QFileInfo sInfo(QString("%1/%2").arg(xdgDir.constData()).arg(name.data()));
     QFileInfo dInfo(sInfo.absoluteDir().absolutePath());
     if (QFile::setPermissions(sInfo.absoluteFilePath(),
-                QFileDevice::ReadOwner | QFileDevice::WriteOwner |
-                QFileDevice::ReadGroup | QFileDevice::WriteGroup)) {
+                QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner |
+                QFileDevice::ReadGroup | QFileDevice::WriteGroup | QFileDevice::ExeGroup |
+                QFileDevice::ReadOther | QFileDevice::WriteOther | QFileDevice::ExeOther)) {
         // TODO: Qt doesn't provide a method to chown at the moment
         qDebug() << "Setting ownership of" << sInfo.absoluteFilePath() << "using /bin/chown";
         QProcess::startDetached("/bin/chown", { QString("%1:%2").arg(dInfo.owner()).arg(dInfo.group()), sInfo.absoluteFilePath() }, "./");
@@ -545,7 +546,7 @@ void WebOSCoreCompositor::onSurfaceMapped(QWaylandSurface *surface, WebOSSurface
 
         qDebug() << item << "Items in compositor: " <<  getItems();
         emit surfaceMapped(item);
-    }        
+    }
 }
 
 WebOSSurfaceItem* WebOSCoreCompositor::activeSurface()

--- a/modules/weboscompositor/weboscorecompositor.cpp
+++ b/modules/weboscompositor/weboscorecompositor.cpp
@@ -235,7 +235,7 @@ WebOSCoreCompositor::WebOSCoreCompositor(ExtensionFlags extensions, const char *
     , m_registered(false)
     , m_extensionFlags(extensions)
 {
-    setSocketName(socketName);
+    checkDaemonFiles();
 
     connect(this, &QWaylandCompositor::surfaceRequested, this, [this] (QWaylandClient *client, uint id, int version) {
         WebOSSurface *surface = new WebOSSurface();
@@ -300,7 +300,6 @@ void WebOSCoreCompositor::create()
 {
     initializeExtensions(m_extensionFlags);
     QWaylandCompositor::create();
-    checkDaemonFiles();
 }
 
 void WebOSCoreCompositor::registerWindow(QQuickWindow *window, QString name)
@@ -391,11 +390,19 @@ void WebOSCoreCompositor::checkDaemonFiles()
 
     QByteArray name(socketName());
     // Similar logic as in wl_display_add_socket()
-    if (name.isEmpty()) {
-        name = qgetenv("WAYLAND_DISPLAY");
+    if (name.isEmpty())
+    {
+        name = qgetenv("WAYLAND_DISPLAY_LSM");
         if (name.isEmpty())
-            name = "wayland-0";
+        {
+            name = qgetenv("WAYLAND_DISPLAY");
+        }
 
+        if (name.isEmpty())
+        {
+            qWarning() << "Using default wayland display socket wayland-0";
+            name = "wayland-0";
+        }
         setSocketName(name);
     }
 


### PR DESCRIPTION
- This allows using Wayland as luna-surfacemanager's output, so lsm becomes a forwarding or nested compositor.

  You can set 
```bash
XDG_RUNTIME_DIR=/path/to/output-compositor/xdg/run 
WAYLAND_DISPLAY="wayland-0" # name of display on output compositor 
WAYLAND_DISPLAY_LSM="wayland-1" # name of display for LSM apps 
WEBOS_COMPOSITOR_PLATFORM=wayland 
```
... then run surface-manager, and surface-manager's output will appear in the host wayland compositor. webOS apps will need to have WAYLAND_DISPLAY set to wayland-1 or they will end up directly on the host compositor, instead of inside LSM.

- Move checkDaemonFiles into constructor, replacing the setSocketName() call, as setSocketName() would default to using WAYLAND_DISPLAY, which would then crash because the host compositor is already using that.
- Check for null on QGuiApplication::primaryScreen() before calling name(), so that the application will crash with a proper fatal error from Qt when no screens are found